### PR TITLE
Refactored rm_map configuration file parsing and modified configuration files to INI file format.

### DIFF
--- a/launchmon/src/ini.c
+++ b/launchmon/src/ini.c
@@ -1,0 +1,185 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#include <stdlib.h>
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char c or ';' comment in given string, or pointer to
+   null at end of string if neither found. ';' must be prefixed by a whitespace
+   character to register as a comment. */
+static char* find_char_or_comment(const char* s, char c)
+{
+    int was_whitespace = 0;
+    while (*s && *s != c && !(was_whitespace && *s == ';')) {
+        was_whitespace = isspace((unsigned char)(*s));
+        s++;
+    }
+    return (char*)s;
+}
+
+/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    strncpy(dest, src, size);
+    dest[size - 1] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file,
+                   int (*handler)(void*, const char*, const char*,
+                                  const char*),
+                   void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+#else
+    char* line;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)malloc(INI_MAX_LINE);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+    /* Scan through file line by line */
+    while (fgets(line, INI_MAX_LINE, file) != NULL) {
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (*start == ';' || *start == '#') {
+            /* Per Python ConfigParser, allow '#' comments at start of line */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-black line with leading whitespace, treat as continuation
+               of previous name's value (as per Python ConfigParser). */
+            if (!handler(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_char_or_comment(start + 1, ']');
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start && *start != ';') {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_char_or_comment(start, '=');
+            if (*end != '=') {
+                end = find_char_or_comment(start, ':');
+            }
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = lskip(end + 1);
+                end = find_char_or_comment(value, '\0');
+                if (*end == ';')
+                    *end = '\0';
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!handler(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+                error = lineno;
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename,
+              int (*handler)(void*, const char*, const char*, const char*),
+              void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}

--- a/launchmon/src/ini.h
+++ b/launchmon/src/ini.h
@@ -1,0 +1,77 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef __INI_H__
+#define __INI_H__
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's ConfigParser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename,
+              int (*handler)(void* user, const char* section,
+                             const char* name, const char* value),
+              void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file,
+                   int (*handler)(void* user, const char* section,
+                                  const char* name, const char* value),
+                   void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   ConfigParser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See http://code.google.com/p/inih/issues/detail?id=21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Nonzero to use stack, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Maximum line length for any line in INI file. */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INI_H__ */

--- a/launchmon/src/ini_reader.cpp
+++ b/launchmon/src/ini_reader.cpp
@@ -1,0 +1,81 @@
+// Read an INI file into easy-to-access name/value pairs.
+
+// inih and INIReader are released under the New BSD license (see LICENSE.txt).
+// Go to the project home page for more info:
+//
+// https://github.com/benhoyt/inih
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include "ini.h"
+#include "ini_reader.h"
+
+using std::string;
+
+INIReader::INIReader(string filename)
+{
+    _error = ini_parse(filename.c_str(), ValueHandler, this);
+}
+
+int INIReader::ParseError()
+{
+    return _error;
+}
+
+string INIReader::Get(string section, string name, string default_value)
+{
+    string key = MakeKey(section, name);
+    return _values.count(key) ? _values[key] : default_value;
+}
+
+long INIReader::GetInteger(string section, string name, long default_value)
+{
+    string valstr = Get(section, name, "");
+    const char* value = valstr.c_str();
+    char* end;
+    // This parses "1234" (decimal) and also "0x4D2" (hex)
+    long n = strtol(value, &end, 0);
+    return end > value ? n : default_value;
+}
+
+double INIReader::GetReal(string section, string name, double default_value)
+{
+    string valstr = Get(section, name, "");
+    const char* value = valstr.c_str();
+    char* end;
+    double n = strtod(value, &end);
+    return end > value ? n : default_value;
+}
+
+bool INIReader::GetBoolean(string section, string name, bool default_value)
+{
+    string valstr = Get(section, name, "");
+    // Convert to lower case to make string comparisons case-insensitive
+    std::transform(valstr.begin(), valstr.end(), valstr.begin(), ::tolower);
+    if (valstr == "true" || valstr == "yes" || valstr == "on" || valstr == "1")
+        return true;
+    else if (valstr == "false" || valstr == "no" || valstr == "off" || valstr == "0")
+        return false;
+    else
+        return default_value;
+}
+
+string INIReader::MakeKey(string section, string name)
+{
+    string key = section + "=" + name;
+    // Convert to lower case to make section/name lookups case-insensitive
+    std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+    return key;
+}
+
+int INIReader::ValueHandler(void* user, const char* section, const char* name,
+                            const char* value)
+{
+    INIReader* reader = (INIReader*)user;
+    string key = MakeKey(section, name);
+    if (reader->_values[key].size() > 0)
+        reader->_values[key] += "\n";
+    reader->_values[key] += value;
+    return 1;
+}

--- a/launchmon/src/ini_reader.h
+++ b/launchmon/src/ini_reader.h
@@ -1,0 +1,53 @@
+// Read an INI file into easy-to-access name/value pairs.
+
+// inih and INIReader are released under the New BSD license (see LICENSE.txt).
+// Go to the project home page for more info:
+//
+// https://github.com/benhoyt/inih
+
+#ifndef __INIREADER_H__
+#define __INIREADER_H__
+
+#include <map>
+#include <string>
+
+// Read an INI file into easy-to-access name/value pairs. (Note that I've gone
+// for simplicity here rather than speed, but it should be pretty decent.)
+class INIReader
+{
+public:
+    // Construct INIReader and parse given filename. See ini.h for more info
+    // about the parsing.
+    INIReader(std::string filename);
+
+    // Return the result of ini_parse(), i.e., 0 on success, line number of
+    // first error on parse error, or -1 on file open error.
+    int ParseError();
+
+    // Get a string value from INI file, returning default_value if not found.
+    std::string Get(std::string section, std::string name,
+                    std::string default_value);
+
+    // Get an integer (long) value from INI file, returning default_value if
+    // not found or not a valid integer (decimal "1234", "-1234", or hex "0x4d2").
+    long GetInteger(std::string section, std::string name, long default_value);
+
+    // Get a real (floating point double) value from INI file, returning
+    // default_value if not found or not a valid floating point value
+    // according to strtod().
+    double GetReal(std::string section, std::string name, double default_value);
+
+    // Get a boolean value from INI file, returning default_value if not found or if
+    // not a valid true/false value. Valid true values are "true", "yes", "on", "1",
+    // and valid false values are "false", "no", "off", "0" (not case sensitive).
+    bool GetBoolean(std::string section, std::string name, bool default_value);
+
+private:
+    int _error;
+    std::map<std::string, std::string> _values;
+    static std::string MakeKey(std::string section, std::string name);
+    static int ValueHandler(void* user, const char* section, const char* name,
+                            const char* value);
+};
+
+#endif  // __INIREADER_H__

--- a/launchmon/src/linux/Makefile.am
+++ b/launchmon/src/linux/Makefile.am
@@ -59,6 +59,9 @@ launchmon_SOURCES       = main.cxx \
                           sdbg_linux_mach.cxx \
                           lmon_api/lmon_say_msg.cxx \
                           sdbg_proc_service.cxx \
+	                  ../ini_reader.cpp \
+                          ../ini_reader.h \
+			  ../ini.c \
                           ../sdbg_self_trace.cxx \
                           ../sdbg_opt.cxx \
                           ../sdbg_rm_map.cxx \

--- a/launchmon/src/linux/lmon_api/Makefile.am
+++ b/launchmon/src/linux/lmon_api/Makefile.am
@@ -63,6 +63,9 @@ libmonfeapi_la_SOURCES       = lmon_fe.cxx \
                                lmon_lmonp_msg.cxx \
                                lmon_coloc_spawner.cxx \
                                lmon_say_msg.cxx \
+			       ../../ini_reader.cpp \
+			       ../../ini_reader.h \
+			       ../../ini.c \
                                ../../sdbg_rm_map.cxx \
                                ../../sdbg_self_trace.cxx \
                                ../../sdbg_opt.cxx \

--- a/launchmon/src/rm_alps.conf
+++ b/launchmon/src/rm_alps.conf
@@ -44,6 +44,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=alps
 RM_MPIR=STD
 RM_launcher=aprun

--- a/launchmon/src/rm_bglrm.conf
+++ b/launchmon/src/rm_bglrm.conf
@@ -44,6 +44,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=bglrm
 RM_MPIR=STD_COLOC
 RM_launcher=mpirun64

--- a/launchmon/src/rm_bgprm.conf
+++ b/launchmon/src/rm_bgprm.conf
@@ -44,6 +44,8 @@
 ## RM_launcher_helper= method or command to launch daemons
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
+
+[configuration]
 RM=bgprm
 RM_MPIR=STD_COLOC
 RM_launcher=mpirun64

--- a/launchmon/src/rm_bgq_slurm.conf
+++ b/launchmon/src/rm_bgq_slurm.conf
@@ -44,6 +44,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=bgq_slurm
 RM_MPIR=STD_COLOC
 RM_launcher=srun

--- a/launchmon/src/rm_bgqrm.conf
+++ b/launchmon/src/rm_bgqrm.conf
@@ -44,6 +44,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=bgqrm
 RM_MPIR=STD_COLOC
 RM_launcher=runjob

--- a/launchmon/src/rm_gupc.conf
+++ b/launchmon/src/rm_gupc.conf
@@ -46,6 +46,7 @@
 ## TODO: do something about kill-support
 ##
 
+[configuration]
 RM=gupc
 RM_MPIR=STD
 RM_launcher=*

--- a/launchmon/src/rm_info.conf
+++ b/launchmon/src/rm_info.conf
@@ -36,23 +36,23 @@
 ##
 
 [linux-x86]
-rm_slurm.conf
-rm_openrte.conf
-rm_mchecker.conf
+file=rm_slurm.conf
+file=rm_openrte.conf
+file=rm_mchecker.conf
 
 [linux-x86_64]
-rm_slurm.conf
-rm_openrte.conf
-rm_alps.conf
-rm_mchecker.conf
-rm_gupc.conf
+file=rm_slurm.conf
+file=rm_openrte.conf
+file=rm_alps.conf
+file=rm_mchecker.conf
+file=rm_gupc.conf
 
 [linux-power]
-rm_bglrm.conf
-rm_bgprm.conf
-rm_bgqrm.conf
-rm_bgq_slurm.conf
-rm_mchecker.conf
+file=rm_bglrm.conf
+file=rm_bgprm.conf
+file=rm_bgqrm.conf
+file=rm_bgq_slurm.conf
+file=rm_mchecker.conf
 
 [linux-power64]
 rm_bgqrm.conf

--- a/launchmon/src/rm_mchecker.conf
+++ b/launchmon/src/rm_mchecker.conf
@@ -44,6 +44,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=modelchecker
 RM_MPIR=STD
 RM_launcher=LE_model_checker

--- a/launchmon/src/rm_openrte.conf
+++ b/launchmon/src/rm_openrte.conf
@@ -45,6 +45,7 @@
 ## RM_launch_str= options and arguements used for RM_launch_mth.
 ##
 
+[configuration]
 RM=openrte
 RM_MPIR=STD_COLOC_FIFO
 RM_launcher=orterun

--- a/launchmon/src/rm_slurm.conf
+++ b/launchmon/src/rm_slurm.conf
@@ -46,6 +46,7 @@
 ## TODO: do something about kill-support
 ##
 
+[configuration]
 RM=slurm
 RM_MPIR=STD
 RM_launcher=srun

--- a/launchmon/src/sdbg_rm_map.cxx
+++ b/launchmon/src/sdbg_rm_map.cxx
@@ -54,10 +54,26 @@
 //# error boost/tokenizer is required; no alternative tokenizer
 //#endif
 
-#include <iostream>
+//include inih files
+#include "ini_reader.h"
 
 #include "sdbg_rm_map.hxx"
 
+///////////////////////////////////////////////////////////////////
+//                                                               //
+// PRIVATE METHOD using stringstream to tokenize                 //
+//                                                               //
+///////////////////////////////////////////////////////////////////
+
+std::vector<std::string>splitByDelimiter(std::string toSplit, const char delimiter) {
+  std::istringstream split(toSplit);
+  std::vector<std::string> token;
+  std::string each;
+  while (std::getline(split, each, delimiter)) {
+    token.push_back(each);
+  }
+  return token;
+}
 
 ///////////////////////////////////////////////////////////////////
 //                                                               //
@@ -297,30 +313,32 @@ resource_manager_t::fill_id(rm_id_t &target_id, const std::string &v)
   std::string id = na;
   std::string dt = na;
 
-  size_t ix = v.find_first_of("|", 0);
-  if (ix != std::string::npos)
-    {
-      key = v.substr(0, ix);
-      size_t ix2 = v.find_first_of("|", ix+1);
-      if (ix2 != std::string::npos)
-        {
-          method = v.substr(ix+1, ix2-(ix+1));
-          size_t ix3 = v.find_first_of("|", ix2+1);
-          if (ix3 != std::string::npos)
-            {
-              id = v.substr(ix2+1, ix3-(ix2+1));
-              dt = v.substr(ix3+1, std::string::npos);
-            }
-          else
-            {
-              id = v.substr(ix2+1, std::string::npos);
-            }
-        }
-      else
-        {
-           method = v.substr(ix+1, std::string::npos);
-        }
+  //std::cout << v << "\n";
+  
+  std::vector<std::string> token = splitByDelimiter(v, '|');
+  int i = 0;
+  for (std::vector<std::string>::const_iterator c_i = token.begin(); c_i != token.end(); c_i++) { 
+    switch (i) {
+      case 0:
+        key = *c_i;
+        break;
+      case 1:
+        method = *c_i;
+        break;
+      case 2:
+        id = *c_i;
+        break;
+      case 3:
+        dt = *c_i;
+        break;
+      default:
+        std::cout << "Unknown part at end of " << v << "\n";
+        break;
     }
+    i++;
+  }
+
+  //std::cout << "NEW" << "\n" << key << "\n" << method << "\n" << id << "\n" << dt << "\n";
 
   if (key == std::string("RM_launcher"))
     {
@@ -395,7 +413,7 @@ resource_manager_t::fill_launcher_so(const std::string &v)
 
 
 void
-resource_manager_t::fill_kill_singals(const std::string &v)
+resource_manager_t::fill_kill_signals(const std::string &v)
 {
   int signal_type = 0;
   size_t ix = 0;
@@ -876,7 +894,6 @@ rc_rm_t::set_resource_manager(const resource_manager_t &rmgr)
   resource_manager = rmgr;
 }
 
-
 ///////////////////////////////////////////////////////////////////
 //
 // PRIVATE METHODS of the rc_rm_t-related class
@@ -901,196 +918,150 @@ resource_manager_t::resolve_signal(const std::string &v)
   return ret_sig;
 }
 
-
 bool
 rc_rm_t::read_supported_rm_confs(const std::string &os_isa_string,
                  const std::string &rm_info_conf_path,
                  std::vector<std::string> &supported_rm_fnames)
 {
-  std::ifstream ri_conf;
-  char line_max[PATH_MAX];
-  bool found = false;
-  bool plat_found = false;
-  std::string a_line;
+  //use inih reader
+  INIReader reader(rm_info_conf_path);
 
-  ri_conf.open(rm_info_conf_path.c_str());
-  if (ri_conf.is_open())
-    {
-       while (!ri_conf.eof())
-         {
-           ri_conf.getline(line_max, PATH_MAX);
-           if (ri_conf.bad() || ri_conf.fail())
-             {
-               self_trace_t::trace ( LEVELCHK(level1),
-                 MODULENAME,1,
-                 "getline enountered an error.");
+  if (reader.ParseError() < 0) {
+    self_trace_t::trace ( LEVELCHK(level1), MODULENAME, 1, "Conf INI file parsing error by INIH code.");
+  }
 
-               break;
-             }
+  //std::cout << "PATH:" << rm_info_conf_path << "\n";
+  //std::cout << "ISA:" << os_isa_string << "\n";
 
-           a_line = line_max;
 
-           if (a_line[0] == '#' || a_line[0] == '\0')
-             continue;
+  std::string aggregate = reader.Get(os_isa_string, "file", "???");
 
-           if (!plat_found) 
-             {
-               if (a_line[0] == '[')
-                 {
-                   size_t ix = a_line.find_first_of(']', 1);
-                   if (ix != std::string::npos)
-                     {
-                       std::string found_os_isa = a_line.substr(1, ix-1);
-                       if (found_os_isa == os_isa_string)
-                         plat_found = true;
-                     }
-                   else
-                     {
-                       self_trace_t::trace ( LEVELCHK(level1),
-                         MODULENAME,1,
-                         "ill-formed line.");
-                     }
-                  }
-             }
-           else
-             {
-               if (a_line[0] == '[')
-                 break; // OK, done with parsing for my platform
-               supported_rm_fnames.push_back(a_line);
-               found = true;
-             }
-         }
-       ri_conf.close();
-    }
+  //std::cout << "file:" << aggregate << "\n";
+  
+  //check for no returned filenames
+  if (strcmp(aggregate.c_str(), "") == 0 || strcmp(aggregate.c_str(), "???") == 0)
+    return false;
 
-  return found;
+  std::vector<std::string> token = splitByDelimiter(aggregate, '\n');
+
+  for (std::vector<std::string>::const_iterator c_i = token.begin(); c_i != token.end(); c_i++) {
+    //std::cout << "filetoken:" << *c_i << "\n";
+    supported_rm_fnames.push_back(*c_i);
+  }
+  
+
+  /*
+  //strtok_r method does not work
+  char * input = strdup(aggregate.c_str());
+  char * pch;
+  char * saveptr;
+  const char delimiter = '\n';
+  pch = strtok_r(input, &delimiter, &saveptr);
+
+  while (pch != NULL) {
+    std::cout << "token:" << pch << "\n";
+    supported_rm_fnames.push_back(pch);
+    pch = strtok_r(NULL, &delimiter, &saveptr);
+  }
+  */
+
+  return true;
 }
-
 
 bool
 rc_rm_t::parse_and_fill_rm(const std::string &rm_conf_path,
                            resource_manager_t &a_rm)
 {
-  std::ifstream inputfile;
-  std::map<std::string, std::vector<std::string> > key_value_pair;
-  std::map<std::string, std::vector<std::string> >::iterator iter;
-  bool error_found = false;
-  char line_max[PATH_MAX];
-  std::string a_line;
+  
+  //use inih reader
+  INIReader reader(rm_conf_path);
 
-  inputfile.open(rm_conf_path.c_str());
+  if (reader.ParseError() < 0) {
+    return true;
+  }
 
-  if (inputfile.is_open())
-    {
-      while (!inputfile.eof())
-        {
-          inputfile.getline(line_max, PATH_MAX);
-          if (inputfile.bad() || inputfile.fail())
-            {
-              self_trace_t::trace ( LEVELCHK(level1),
-                MODULENAME,1,
-                "getline encountered an error.");
+  //std::cout << "PATH:" << rm_conf_path << "\n";
 
-              break;
-            }
+  std::string section = "configuration";
 
-          a_line = line_max;
-          if (a_line[0] == '#' || a_line[0] == '\n')
-            continue;
+  std::string keys[] = {
+    "RM", 
+    "RM_MPIR", 
+    "RM_launcher", 
+    "RM_launcher_id", 
+    "RM_launcher_so", 
+    "RM_jobid", 
+    "RM_signal_for_kill", 
+    "RM_fail_detection",
+    "RM_launch_helper", 
+    "RM_launch_str"
+  };
 
-          size_t equal = a_line.find_first_of('=', 0);
-          if (equal != std::string::npos)
-            {
-              std::string key = a_line.substr(0, equal);
-              std::string value = a_line.substr(equal+1, std::string::npos);
-              iter = key_value_pair.find(key);
+  int i;
+  std::string beach; 
+  for (i = 0; i < 10; i++) {
+    std::string aggregate = reader.Get(section, keys[i], "");
 
-              if (iter == key_value_pair.end())
-                {
-                  std::vector<std::string> value_vect;
-                  value_vect.push_back(value);
-                  key_value_pair[key] = value_vect;
-                }
-              else
-                {
-                  iter->second.push_back(value);
-                }
-            }
-          else
-            {
-              self_trace_t::trace ( LEVELCHK(level1),
-                MODULENAME,1,
-                "ill-formed line.");
-
-              error_found = true;
-            }
-        }
-      inputfile.close();
+    //check for blank or not found
+    if (strcmp(aggregate.c_str(), "") == 0) {
+      //std::cout << "Alert: No value found for key " << keys[i] << "\n";
+      continue;
     }
 
-  iter = key_value_pair.find(std::string("RM"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_rm_type (iter->second[0]);
-    }
+    std::vector<std::string> token = splitByDelimiter(aggregate, '\n');
 
-  iter = key_value_pair.find(std::string("RM_MPIR"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_mpir_type (iter->second[0]);
-    }
+    if (token.empty())
+      continue;
 
-  iter = key_value_pair.find(std::string("RM_launcher"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launchers(iter->second);
+    /*
+    for (std::vector<std::string>::const_iterator c_i = token.begin(); c_i != token.end(); c_i++) {
+      std::cout << keys[i] << ":" << *c_i << "\n";
     }
+    */
 
-  iter = key_value_pair.find(std::string("RM_launcher_id"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launcher_id(iter->second);
+    //actions based on index in keys[]
+    switch (i) {
+      case 0:
+        a_rm.fill_rm_type(token.front());
+        beach = token.front();
+
+        break;
+      case 1:
+        a_rm.fill_rm_type(token.front());
+        break;
+      case 2:
+        a_rm.fill_launchers(token);
+        break;
+      case 3:
+        a_rm.fill_launcher_id(token);
+        break;
+      case 4:
+        a_rm.fill_launcher_so(token.front());
+        break;
+      case 5:
+        a_rm.fill_job_id(token.front());
+        break;
+      case 6:
+        a_rm.fill_kill_signals(token.front());
+        break;
+      case 7:
+        a_rm.fill_fail_detection(token.front());
+        break;
+      case 8:
+        a_rm.fill_launch_helper(token.front());
+        break;
+      case 9:
+        a_rm.fill_launch_string(token.front());
+        break;
+      default:
+        std::cout << "Alert: Out of bounds" << "\n";
+        break;
     }
-
-  iter = key_value_pair.find(std::string("RM_launcher_so"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launcher_so(iter->second[0]);
-    }
-
-  iter = key_value_pair.find(std::string("RM_jobid"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_job_id(iter->second[0]);
-    }
-
-  iter
-    = key_value_pair.find(std::string("RM_signal_for_kill"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_kill_singals(iter->second[0]);
-    }
-
-  iter
-    = key_value_pair.find(std::string("RM_fail_detection"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_fail_detection(iter->second[0]);
-    }
-
-  iter = key_value_pair.find(std::string("RM_launch_helper"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launch_helper(iter->second[0]);
-    }
-
-  iter = key_value_pair.find(std::string("RM_launch_str"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launch_string(iter->second[0]);
-    }
-
-  return error_found;
+  }  
+  //we must re-set the rm type afterwards for some reason or else execvp will not start for tests
+  a_rm.fill_rm_type(beach);
+ 
+  return false;
 }
 
 

--- a/launchmon/src/sdbg_rm_map.hxx
+++ b/launchmon/src/sdbg_rm_map.hxx
@@ -230,7 +230,7 @@ public:
   void fill_launcher_id(const std::vector<std::string> &vect);
   void fill_id(rm_id_t &id, const std::string &v);
   void fill_fail_detection(const std::string &vect);
-  void fill_kill_singals(const std::string &v);
+  void fill_kill_signals(const std::string &v);
   void fill_launcher_so(const std::string &v);
   void fill_launch_helper(const std::string &v);
   void fill_launch_string(const std::string &v);


### PR DESCRIPTION
Modified current RM configuration files to resemble [INI file format](http://en.wikipedia.org/wiki/INI_file). 
* rm_info.conf
  * ISAs are now formatted as section names. ex: `[linux-x86]`
  * Supported ISA RM conf files are identified under an RM as values to the *file* key. ex: `file=slurm.conf`
* rm_xxx.conf
  * Keys and values are now under a section named *configuration*. 
ex: 
```
[configuration]
RM=slurm
key=value
```

Refactored rm_map implementation to use [benhoyt/inih](https://github.com/benhoyt/inih/) for reading configuration file. 
* Methods modified:
  * `fill_id`
  * `read_supported_rm_confs`
  * `parse_and_fill_rm`
  * Added helper method to `sdbg_rm_map.cxx` to tokenize key values. 
```c++
std::vector<std::string>splitByDelimiter(std::string toSplit, const char delimiter)
``` 
* Renamed method `fill_kill_singals` to `fill_kill_signals`.